### PR TITLE
fix(security): override webpack-dev-server to ^5.2.4 (CVE-2026-6402)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13300,9 +13300,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "serialize-javascript": "^7.0.5",
     "immutable": "^5.1.5",
     "glob": "^13.0.6",
-    "rimraf": "^6.0.1"
+    "rimraf": "^6.0.1",
+    "webpack-dev-server": "^5.2.4"
   }
 }


### PR DESCRIPTION
## Summary

Fixes Dependabot alert #259: **webpack-dev-server cross-origin source code exposure** (CVE-2026-6402, medium severity).

## Root Cause

`webpack-dev-server` is a transitive dependency pulled in by `@angular-devkit/build-angular`, which hard-pins version `5.2.3` (vulnerable). Angular 21.2.12 (latest stable) and Angular 22 RC both still ship `5.2.3` — no upstream fix available yet.

## Fix

Added `"webpack-dev-server": "^5.2.4"` to the existing `overrides` block in `package.json`. This forces npm to install the patched version regardless of what Angular declares.

**Confirmed:** `node_modules/webpack-dev-server` is now `5.2.4`.

## Related

- Dependabot alert #259 / CVE-2026-6402
- uuid alert #260 is a separate issue (no safe fix — sockjs pins `uuid ^8.3.2` and uuid v10+ is ESM-only)